### PR TITLE
Fix issue where mobile users cannot use bee!bottom command

### DIFF
--- a/src/main/bot/commands/fun/score.ts
+++ b/src/main/bot/commands/fun/score.ts
@@ -2,7 +2,7 @@ import * as DiscordClient from 'discord.js'
 import { BaseCommand, Command } from 'bot/commands/command'
 import { DatabaseHelper } from 'common/database'
 
-const COMMAND_STRING = /^bee!bottom\s?(<@!(?<userId>\d{17,19})>)?$/
+const COMMAND_STRING = /^bee!bottom\s?(<@!(?<userId>\d{17,19})>)?\s*$/
 
 @Command.register
 export class Score extends BaseCommand {

--- a/src/test/bot/commands/fun/score.spec.ts
+++ b/src/test/bot/commands/fun/score.spec.ts
@@ -19,6 +19,10 @@ describe('Score Command', function () {
     it('When a message contains bee!bottom and a user', async function () {
       await checkAndAssertMatches(`bee!bottom ${DiscordTestHelper.MOCK_USER_STRING}`)
     })
+
+    it('When a message contains bee!bottom and a user with extra whitespace at the end', async function () {
+      await checkAndAssertMatches(`bee!bottom ${DiscordTestHelper.MOCK_USER_STRING}       `)
+    })
   })
 
   describe('Should not trigger', function () {


### PR DESCRIPTION
Add trailing whitespace match to regex for bee!bottom so default formatting for mobile messages get caught.