### PR TITLE
Fix Queue and Score commands for mobile users

### DIFF
--- a/src/main/bot/bot.ts
+++ b/src/main/bot/bot.ts
@@ -86,6 +86,8 @@ export class BeeBot {
       return
     }
 
+    logger.info(message.content)
+
     this.registeredCommands.forEach((c) => {
       const matches = c.checkTrigger(message)
       if (matches) {

--- a/src/main/bot/commands/fun/score.ts
+++ b/src/main/bot/commands/fun/score.ts
@@ -2,7 +2,7 @@ import * as DiscordClient from 'discord.js'
 import { BaseCommand, Command } from 'bot/commands/command'
 import { DatabaseHelper } from 'common/database'
 
-const COMMAND_STRING = /^bee!bottom\s?(<@!(?<userId>\d{17,19})>)?\s*$/
+const COMMAND_STRING = /^bee!bottom\s?(<@!?(?<userId>\d{17,19})>)?\s*$/
 
 @Command.register
 export class Score extends BaseCommand {

--- a/src/main/bot/commands/spotify/queue-song.ts
+++ b/src/main/bot/commands/spotify/queue-song.ts
@@ -7,7 +7,7 @@ import * as logger from 'winston'
 
 const NAME = 'bee!queue [user] <song_name>'
 const DESCRIPTION = 'Searches for and adds it to a play queue'
-const COMMAND_STRING: RegExp = /^bee!queue(?:\s<@!(?<userId>\d{17,19})>?)?(?:\s(?<songName>.+))?$/
+const COMMAND_STRING: RegExp = /^bee!queue(?:\s<@!?(?<userId>\d{17,19})>?)?(?:\s(?<songName>.+))?$/
 
 @Command.register
 export class QueueSong extends BaseCommand {

--- a/src/test/bot/commands/fun/score.spec.ts
+++ b/src/test/bot/commands/fun/score.spec.ts
@@ -23,6 +23,10 @@ describe('Score Command', function () {
     it('When a message contains bee!bottom and a user with extra whitespace at the end', async function () {
       await checkAndAssertMatches(`bee!bottom ${DiscordTestHelper.MOCK_USER_STRING}       `)
     })
+
+    it('When a message contains bee!bottom and a user that has no exclamation mark in their user id', async function () {
+      await checkAndAssertMatches(`bee!bottom ${DiscordTestHelper.MOCK_MOBILE_USER_STRING}       `)
+    })
   })
 
   describe('Should not trigger', function () {

--- a/src/test/bot/commands/spotify/queue.spec.ts
+++ b/src/test/bot/commands/spotify/queue.spec.ts
@@ -63,6 +63,19 @@ describe('Queue Command', function () {
         sinon.assert.calledWith(message.channel.send, `Added the song \`A Song by An artist\` to <@!${MockSpotifyHelper.USER_1_ID}>\'s Beelist and queue`)
       })
 
+      it('should queue the song when the song is found and the command is sent from mobile', async function () {
+        const message = await checkAndAssertMatches(`bee!queue <@${MockSpotifyHelper.USER_1_ID}> song name`)
+        const spotifyApi = MockSpotifyHelper.spotify()
+        sinon.assert.calledOnce(spotifyApi.searchTracks)
+        sinon.assert.calledWith(spotifyApi.searchTracks, 'song name')
+        const request = MockSpotifyHelper.request()
+        sinon.assert.calledOnce(request.post)
+        assert.isTrue(request.post.firstCall.firstArg.url.includes(MockSpotifyHelper.trackDataFound.body.tracks.items[0].uri))
+        sinon.assert.calledOnce(spotifyApi.addTracksToPlaylist)
+        sinon.assert.calledWith(spotifyApi.addTracksToPlaylist, 'Beelist For User 1', ['a uri'])
+        sinon.assert.calledWith(message.channel.send, `Added the song \`A Song by An artist\` to <@!${MockSpotifyHelper.USER_1_ID}>\'s Beelist and queue`)
+      })
+
       it('should output an error when the song is not found', async function () {
         const message = await checkAndAssertMatches(`bee!queue <@!${MockSpotifyHelper.USER_1_ID}> invalid song name`)
         const spotifyApi = MockSpotifyHelper.spotify()

--- a/src/test/helper/discordTestingHelper.ts
+++ b/src/test/helper/discordTestingHelper.ts
@@ -5,6 +5,7 @@ import { BeeBot } from 'bot/bot'
 export class DiscordTestHelper {
 
   public static readonly MOCK_USER_STRING = '<@!123456789123456782>'
+  public static readonly MOCK_MOBILE_USER_STRING = '<@123456789123456782>'
   public static readonly MOCK_USER_ID = 'mock-id'
   public static createMockMessage (content: string) {
     let message: Message = sinon.createStubInstance(Message)


### PR DESCRIPTION
Make the `!` in the user id string pattern match for bee!queue and bee!bottom commands optional so it is picked up for both mobile and desktop users.